### PR TITLE
Add town and nation shops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.100.4.0</version>
+            <version>0.101.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/acrobot/chestshop/towny/Permission.java
+++ b/src/main/java/com/acrobot/chestshop/towny/Permission.java
@@ -6,7 +6,9 @@ import org.bukkit.entity.Player;
  * @author Acrobot
  */
 public enum Permission {
-    PROTECTION_BYPASS("ChestShop.towny.bypass");
+    PROTECTION_BYPASS("ChestShop.towny.bypass"),
+    TOWN_SHOP("ChestShop.towny.townshop"),
+    NATION_SHOP("ChestShop.towny.nationshop");
 
     private final String permission;
 

--- a/src/main/java/com/acrobot/chestshop/towny/Towny.java
+++ b/src/main/java/com/acrobot/chestshop/towny/Towny.java
@@ -1,8 +1,15 @@
 package com.acrobot.chestshop.towny;
 
 import com.Acrobot.Breeze.Configuration.Configuration;
+import com.acrobot.chestshop.towny.listeners.AccountAccessListener;
+import com.acrobot.chestshop.towny.listeners.AccountQueryListener;
+import com.acrobot.chestshop.towny.listeners.CurrencyAddListener;
+import com.acrobot.chestshop.towny.listeners.PlotListener;
+import com.acrobot.chestshop.towny.listeners.SignValidationListener;
+import com.acrobot.chestshop.towny.listeners.TransactionListener;
 import com.acrobot.chestshop.towny.properties.Properties;
 import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -30,8 +37,18 @@ public class Towny extends JavaPlugin {
             return;
         }
 
+        PluginManager pluginManager = getServer().getPluginManager();
+
         if (Properties.BUILDING_INSIDE_PLOTS) {
-            getServer().getPluginManager().registerEvents(new PlotListener(), this);
+            pluginManager.registerEvents(new PlotListener(), this);
+        }
+
+        if (Properties.ALLOW_TOWN_SHOPS || Properties.ALLOW_NATION_SHOPS) {
+            pluginManager.registerEvents(new AccountAccessListener(), this);
+            pluginManager.registerEvents(new AccountQueryListener(), this);
+            pluginManager.registerEvents(new CurrencyAddListener(), this);
+            pluginManager.registerEvents(new SignValidationListener(), this);
+            pluginManager.registerEvents(new TransactionListener(), this);
         }
     }
 

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -19,8 +19,10 @@ import org.bukkit.entity.Player;
  */
 public class TownyUtils {
 
-    final static String townShopPrefix = Properties.TOWN_SHOP_PREFIX;
-    final static String nationShopPrefix = Properties.NATION_SHOP_PREFIX;
+    private static final boolean allowTownShops = Properties.ALLOW_TOWN_SHOPS;
+    private static final boolean allowNationShops = Properties.ALLOW_NATION_SHOPS;
+    private static final String townShopPrefix = Properties.TOWN_SHOP_PREFIX;
+    private static final String nationShopPrefix = Properties.NATION_SHOP_PREFIX;
 
     /**
      * Checks if the player is a resident of a given location
@@ -131,6 +133,9 @@ public class TownyUtils {
     }
 
     public static boolean isTownShop(String owner) {
+        if (!allowTownShops) {
+            return false;
+        }
         int prefixLength = townShopPrefix.length();
         String strippedOwner = owner.replace(" ", "");
         // Check if sign line is less than the length of the townShopPrefix and that it contains the townShopPrefix
@@ -160,6 +165,9 @@ public class TownyUtils {
     }
 
     public static boolean isNationShop(String owner) {
+        if (!allowNationShops) {
+            return false;
+        }
         int prefixLength = nationShopPrefix.length();
         String strippedOwner = owner.replace(" ", "");
         // Check if sign line is less than the length of the nation shop prefix and that it contains the nationShopPrefix

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -1,11 +1,16 @@
 package com.acrobot.chestshop.towny;
 
+import com.Acrobot.ChestShop.Database.Account;
+import com.acrobot.chestshop.towny.properties.Properties;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockOwner;
 import com.palmergames.bukkit.towny.object.TownBlockType;
+import com.palmergames.bukkit.towny.object.economy.BankAccount;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -13,6 +18,9 @@ import org.bukkit.entity.Player;
  * @author Acrobot
  */
 public class TownyUtils {
+
+    final static String townShopPrefix = Properties.TOWN_SHOP_PREFIX;
+    final static String nationShopPrefix = Properties.NATION_SHOP_PREFIX;
 
     /**
      * Checks if the player is a resident of a given location
@@ -120,5 +128,63 @@ public class TownyUtils {
         }
 
         return true;
+    }
+
+    public static boolean isTownShop(String owner) {
+        int prefixLength = townShopPrefix.length();
+        String strippedOwner = owner.replace(" ", "");
+        // Check if sign line is less than the length of the townShopPrefix and that it contains the townShopPrefix
+        if (strippedOwner.length() < prefixLength || !strippedOwner.startsWith(townShopPrefix))
+            return false;
+
+        return !TownyUtils.getTownNameFromPrefixedName(strippedOwner).isEmpty();
+    }
+
+    public static Account getTownAccount(String name) {
+        Town town = TownyAPI.getInstance().getTown(TownyUtils.getTownNameFromPrefixedName(name));
+        BankAccount townAccount = town.getAccount();
+        String accountName = townShopPrefix.concat(town.getName());
+        return new Account(accountName, townAccount.getUUID());
+    }
+
+    public static String getTownNameFromPrefixedName(String prefixedName) {
+        // Remove town shop townShopPrefix
+        String strippedName = prefixedName.substring(townShopPrefix.length());
+        for (Town town : TownyAPI.getInstance().getTowns()) {
+            String townName = town.getName();
+            if (townName.equalsIgnoreCase(strippedName)) {
+                return townName;
+            }
+        }
+        return "";
+    }
+
+    public static boolean isNationShop(String owner) {
+        int prefixLength = nationShopPrefix.length();
+        String strippedOwner = owner.replace(" ", "");
+        // Check if sign line is less than the length of the nation shop prefix and that it contains the nationShopPrefix
+        if (strippedOwner.length() < prefixLength || !strippedOwner.startsWith(nationShopPrefix))
+            return false;
+
+        return !TownyUtils.getNationNameFromPrefixedName(strippedOwner).isEmpty();
+    }
+
+    public static Account getNationAccount(String name) {
+        Nation nation = TownyAPI.getInstance().getNation(TownyUtils.getNationNameFromPrefixedName(name));
+        BankAccount nationAccount = nation.getAccount();
+        String accountName = nationShopPrefix.concat(nation.getName());
+        return new Account(accountName, nationAccount.getUUID());
+    }
+
+    public static String getNationNameFromPrefixedName(String prefixedName) {
+        // Remove nation shop nationShopPrefix
+        String strippedName = prefixedName.substring(nationShopPrefix.length());
+        for (Nation nation : TownyAPI.getInstance().getNations()) {
+            String nationName = nation.getName();
+            if (nationName.equalsIgnoreCase(strippedName)) {
+                return nationName;
+            }
+        }
+        return "";
     }
 }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/AccountAccessListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/AccountAccessListener.java
@@ -1,0 +1,43 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.ChestShop;
+import com.Acrobot.ChestShop.Events.AccountAccessEvent;
+import com.acrobot.chestshop.towny.Permission;
+import com.acrobot.chestshop.towny.TownyUtils;
+import com.palmergames.bukkit.towny.TownyAPI;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class AccountAccessListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onAccountAccess(AccountAccessEvent event) {
+        String name = event.getAccount().getName();
+        if (TownyUtils.isTownShop(name)) {
+            if (Permission.has(event.getPlayer(), Permission.TOWN_SHOP)) {
+                if (TownyAPI.getInstance().getTown(TownyUtils.getTownNameFromPrefixedName(name)) == TownyAPI.getInstance().getTown(event.getPlayer()) || com.Acrobot.ChestShop.Permission.has(event.getPlayer(), com.Acrobot.ChestShop.Permission.ADMIN)) {
+                    event.setAccess(true);
+                } else {
+                    ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a town shop for a town that they do not belong to");
+                    event.setAccess(false);
+                }
+            } else {
+                ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a town shop and they don't have the permission " + Permission.TOWN_SHOP);
+                event.setAccess(false);
+            }
+        } else if (TownyUtils.isNationShop(name)) {
+            if (Permission.has(event.getPlayer(), Permission.NATION_SHOP)) {
+                if (TownyAPI.getInstance().getNation(TownyUtils.getNationNameFromPrefixedName(name)) == TownyAPI.getInstance().getNation(event.getPlayer()) || com.Acrobot.ChestShop.Permission.has(event.getPlayer(), com.Acrobot.ChestShop.Permission.ADMIN)) {
+                    event.setAccess(true);
+                } else {
+                    ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a nation shop for a nation that they do not belong to");
+                    event.setAccess(false);
+                }
+            } else {
+                ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a nation shop and they don't have the permission " + Permission.TOWN_SHOP);
+                event.setAccess(false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/AccountQueryListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/AccountQueryListener.java
@@ -1,0 +1,20 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.AccountQueryEvent;
+import com.acrobot.chestshop.towny.TownyUtils;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class AccountQueryListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onAccountQuery(AccountQueryEvent event) {
+        String name = event.getName();
+        if (TownyUtils.isTownShop(name)) {
+            event.setAccount(TownyUtils.getTownAccount(name));
+        } else if (TownyUtils.isNationShop(name)) {
+            event.setAccount(TownyUtils.getNationAccount(name));
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/CurrencyAddListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/CurrencyAddListener.java
@@ -1,0 +1,34 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.Economy.CurrencyAddEvent;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class CurrencyAddListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public static void onCurrencyAdd(CurrencyAddEvent event) {
+        if (event.wasHandled()) {
+            return;
+        }
+
+        Town town = TownyAPI.getInstance().getTown(event.getTarget());
+
+        if (town != null) {
+            town.getAccount().deposit(event.getAmount().doubleValue(), "Purchase from town shop.");
+            event.setHandled(true);
+            return;
+        }
+
+        Nation nation = TownyAPI.getInstance().getNation(event.getTarget());
+
+        if (nation != null) {
+            nation.getAccount().deposit(event.getAmount().doubleValue(), "Purchase from nation shop.");
+            event.setHandled(true);
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/PlotListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/PlotListener.java
@@ -1,6 +1,7 @@
-package com.acrobot.chestshop.towny;
+package com.acrobot.chestshop.towny.listeners;
 
 import com.Acrobot.ChestShop.Events.Protection.BuildPermissionEvent;
+import com.acrobot.chestshop.towny.Permission;
 import com.acrobot.chestshop.towny.properties.Properties;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/SignValidationListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/SignValidationListener.java
@@ -1,0 +1,18 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.SignValidationEvent;
+import com.acrobot.chestshop.towny.TownyUtils;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class SignValidationListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onSignValidation(SignValidationEvent event) {
+        String owner = event.getOwner();
+        if (TownyUtils.isTownShop(owner) || TownyUtils.isNationShop(owner)) {
+            event.setValid(true);
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/TransactionListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/TransactionListener.java
@@ -1,0 +1,20 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.TransactionEvent;
+import com.acrobot.chestshop.towny.TownyUtils;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class TransactionListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onTransaction(TransactionEvent event) {
+        String name = event.getOwnerAccount().getName();
+        if (TownyUtils.isTownShop(name)) {
+            event.getOwnerAccount().setName(TownyUtils.getTownNameFromPrefixedName(name));
+        } else if (TownyUtils.isNationShop(name)) {
+            event.getOwnerAccount().setName(TownyUtils.getNationNameFromPrefixedName(name));
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/properties/Properties.java
+++ b/src/main/java/com/acrobot/chestshop/towny/properties/Properties.java
@@ -8,11 +8,23 @@ import com.Acrobot.Breeze.Configuration.Annotations.ConfigurationComment;
 public class Properties {
 
     @ConfigurationComment("Should people only be able to build shops inside plots?")
-    public static final boolean BUILDING_INSIDE_PLOTS = true;
+    public static boolean BUILDING_INSIDE_PLOTS = true;
 
     @ConfigurationComment("Should people only be able to build shops inside commercial plots?")
-    public static final boolean BUILDING_INSIDE_SHOP_PLOTS = true;
+    public static boolean BUILDING_INSIDE_SHOP_PLOTS = true;
 
     @ConfigurationComment("If true, only plot owners are able to build inside a shop plot. If false, every town's resident is able to build there.")
-    public static final boolean SHOPS_FOR_OWNERS_ONLY = true;
+    public static boolean SHOPS_FOR_OWNERS_ONLY = true;
+
+    @ConfigurationComment("Should shops that belong to a town be allowed?")
+    public static boolean ALLOW_TOWN_SHOPS = true;
+
+    @ConfigurationComment("What should the town name be prefixed with on the first line of the sign?")
+    public static String TOWN_SHOP_PREFIX = "t-";
+
+    @ConfigurationComment("Should shops that belong to a nation be allowed?")
+    public static boolean ALLOW_NATION_SHOPS = true;
+
+    @ConfigurationComment("What should the nation name be prefixed with on the first line of the sign?")
+    public static String NATION_SHOP_PREFIX = "n-";
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,3 +8,11 @@ author: Acrobot
 description: A towny integration for ChestShop 
  
 depend: [ChestShop, Towny]
+
+permissions:
+  ChestShop.towny.bypass:
+    default: op
+  ChestShop.towny.townshop:
+    default: op
+  ChestShop.towny.nationshop:
+    default: op


### PR DESCRIPTION
This PR adds the ability for town and nation owned shops.

This PR requires at least [build #433](https://ci.minebench.de/job/ChestShop-3/433/) of ChestShop due to a new event being added that enabled this.

The Towny version (and minimum compatible version) had to be updated due methods that are used by this PR, namely the getUUID method, added in version 0.100.4.6.

**Changes**

- Added permissions:
  - `ChestShop.towny.townshop` allows players to make town shops.
  - `ChestShop.towny.nationshop` allows players to make nation shops.

- Added permissions to plugin.yml.

- Removed final keyword from configuration generator due to this error: https://gist.github.com/SulkyWhale/ecf8b8b1191b00d444f423fc7b2ed80c

- Added config options for this feature.