### PR TITLE
Add separate buy and sell permissions for town and nation shops

### DIFF
--- a/src/main/java/com/acrobot/chestshop/towny/Permission.java
+++ b/src/main/java/com/acrobot/chestshop/towny/Permission.java
@@ -7,8 +7,12 @@ import org.bukkit.entity.Player;
  */
 public enum Permission {
     PROTECTION_BYPASS("ChestShop.towny.bypass"),
-    TOWN_SHOP("ChestShop.towny.townshop"),
-    NATION_SHOP("ChestShop.towny.nationshop");
+    TOWN_SHOP("ChestShop.towny.create.townshop"),
+    TOWN_SHOP_BUY("ChestShop.towny.create.townshop.buy"),
+    TOWN_SHOP_SELL("ChestShop.towny.create.townshop.sell"),
+    NATION_SHOP("ChestShop.towny.create.nationshop"),
+    NATION_SHOP_BUY("ChestShop.towny.create.nationshop.buy"),
+    NATION_SHOP_SELL("ChestShop.towny.create.nationshop.sell");
 
     private final String permission;
 
@@ -16,8 +20,12 @@ public enum Permission {
         this.permission = permission;
     }
 
-    public static boolean has(Player player, Permission permission) {
-        return has(player, permission.permission);
+    public static boolean has(Player player, Permission... permissions) {
+        for (Permission permission : permissions) {
+            if (has(player, permission.permission))
+                return true;
+        }
+        return false;
     }
 
     public static boolean has(Player player, String node) {

--- a/src/main/java/com/acrobot/chestshop/towny/Towny.java
+++ b/src/main/java/com/acrobot/chestshop/towny/Towny.java
@@ -5,6 +5,8 @@ import com.acrobot.chestshop.towny.listeners.AccountAccessListener;
 import com.acrobot.chestshop.towny.listeners.AccountQueryListener;
 import com.acrobot.chestshop.towny.listeners.CurrencyAddListener;
 import com.acrobot.chestshop.towny.listeners.PlotListener;
+import com.acrobot.chestshop.towny.listeners.PreShopCreationListener;
+import com.acrobot.chestshop.towny.listeners.ProtectionCheckListener;
 import com.acrobot.chestshop.towny.listeners.SignValidationListener;
 import com.acrobot.chestshop.towny.listeners.TransactionListener;
 import com.acrobot.chestshop.towny.properties.Properties;
@@ -49,6 +51,10 @@ public class Towny extends JavaPlugin {
             pluginManager.registerEvents(new CurrencyAddListener(), this);
             pluginManager.registerEvents(new SignValidationListener(), this);
             pluginManager.registerEvents(new TransactionListener(), this);
+            pluginManager.registerEvents(new PreShopCreationListener(), this);
+            if (Properties.CHEST_ACCESS_BY_PERMISSION) {
+                pluginManager.registerEvents(new ProtectionCheckListener(), this);
+            }
         }
     }
 

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -1,5 +1,6 @@
 package com.acrobot.chestshop.towny;
 
+import com.Acrobot.Breeze.Utils.PriceUtil;
 import com.Acrobot.ChestShop.Database.Account;
 import com.acrobot.chestshop.towny.properties.Properties;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -194,5 +195,21 @@ public class TownyUtils {
             }
         }
         return "";
+    }
+
+    public static void checkShopPerms(Player player, String ownerLine, String priceLine, Runnable denyAction) {
+        if (TownyUtils.isTownShop(ownerLine)) {
+            if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_BUY)) {
+                denyAction.run();
+            } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_SELL)) {
+                denyAction.run();
+            }
+        } else if (TownyUtils.isNationShop(ownerLine)) {
+            if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_BUY)) {
+                denyAction.run();
+            } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_SELL)) {
+                denyAction.run();
+            }
+        }
     }
 }

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -6,7 +6,6 @@ import com.acrobot.chestshop.towny.properties.Properties;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -198,18 +197,18 @@ public class TownyUtils {
         return "";
     }
 
-    public static void checkShopPerms(Player player, String ownerLine, String priceLine) throws TownyException {
+    public static void checkShopPerms(Player player, String ownerLine, String priceLine) throws Exception {
         if (TownyUtils.isTownShop(ownerLine)) {
             if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_BUY)) {
-                throw new TownyException("&cYou do not have permission.");
+                throw new Exception("&cYou do not have permission.");
             } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_SELL)) {
-                throw new TownyException("&cYou do not have permission.");
+                throw new Exception("&cYou do not have permission.");
             }
         } else if (TownyUtils.isNationShop(ownerLine)) {
             if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_BUY)) {
-                throw new TownyException("&cYou do not have permission.");
+                throw new Exception("&cYou do not have permission.");
             } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_SELL)) {
-                throw new TownyException("&cYou do not have permission.");
+                throw new Exception("&cYou do not have permission.");
             }
         }
     }

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -6,6 +6,7 @@ import com.acrobot.chestshop.towny.properties.Properties;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -197,18 +198,18 @@ public class TownyUtils {
         return "";
     }
 
-    public static void checkShopPerms(Player player, String ownerLine, String priceLine, Runnable denyAction) {
+    public static void checkShopPerms(Player player, String ownerLine, String priceLine) throws TownyException {
         if (TownyUtils.isTownShop(ownerLine)) {
             if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_BUY)) {
-                denyAction.run();
+                throw new TownyException("&cYou do not have permission.");
             } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.TOWN_SHOP_SELL)) {
-                denyAction.run();
+                throw new TownyException("&cYou do not have permission.");
             }
         } else if (TownyUtils.isNationShop(ownerLine)) {
             if (PriceUtil.hasBuyPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_BUY)) {
-                denyAction.run();
+                throw new TownyException("&cYou do not have permission.");
             } else if (PriceUtil.hasSellPrice(priceLine) && !Permission.has(player, Permission.NATION_SHOP_SELL)) {
-                denyAction.run();
+                throw new TownyException("&cYou do not have permission.");
             }
         }
     }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/AccountAccessListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/AccountAccessListener.java
@@ -15,7 +15,7 @@ public class AccountAccessListener implements Listener {
     public void onAccountAccess(AccountAccessEvent event) {
         String name = event.getAccount().getName();
         if (TownyUtils.isTownShop(name)) {
-            if (Permission.has(event.getPlayer(), Permission.TOWN_SHOP)) {
+            if (Permission.has(event.getPlayer(), Permission.TOWN_SHOP_BUY, Permission.TOWN_SHOP_SELL)) {
                 if (TownyAPI.getInstance().getTown(TownyUtils.getTownNameFromPrefixedName(name)) == TownyAPI.getInstance().getTown(event.getPlayer()) || com.Acrobot.ChestShop.Permission.has(event.getPlayer(), com.Acrobot.ChestShop.Permission.ADMIN)) {
                     event.setAccess(true);
                 } else {
@@ -27,7 +27,7 @@ public class AccountAccessListener implements Listener {
                 event.setAccess(false);
             }
         } else if (TownyUtils.isNationShop(name)) {
-            if (Permission.has(event.getPlayer(), Permission.NATION_SHOP)) {
+            if (Permission.has(event.getPlayer(), Permission.NATION_SHOP_BUY, Permission.NATION_SHOP_SELL)) {
                 if (TownyAPI.getInstance().getNation(TownyUtils.getNationNameFromPrefixedName(name)) == TownyAPI.getInstance().getNation(event.getPlayer()) || com.Acrobot.ChestShop.Permission.has(event.getPlayer(), com.Acrobot.ChestShop.Permission.ADMIN)) {
                     event.setAccess(true);
                 } else {
@@ -35,7 +35,7 @@ public class AccountAccessListener implements Listener {
                     event.setAccess(false);
                 }
             } else {
-                ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a nation shop and they don't have the permission " + Permission.TOWN_SHOP);
+                ChestShop.logDebug(event.getPlayer().getName() + " cannot use the name " + name + " as it's a nation shop and they don't have the permission " + Permission.NATION_SHOP);
                 event.setAccess(false);
             }
         }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
@@ -1,0 +1,29 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.PreShopCreationEvent;
+import com.Acrobot.ChestShop.Signs.ChestShopSign;
+import com.acrobot.chestshop.towny.TownyUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import static com.Acrobot.ChestShop.Events.PreShopCreationEvent.CreationOutcome.NO_PERMISSION;
+
+public class PreShopCreationListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPreShopCreation(PreShopCreationEvent event) {
+        Player player = event.getPlayer();
+        if (com.Acrobot.ChestShop.Permission.has(player, com.Acrobot.ChestShop.Permission.ADMIN))
+            return;
+
+        String[] signLines = event.getSignLines();
+
+        TownyUtils.checkShopPerms(
+                player,
+                ChestShopSign.getOwner(signLines),
+                ChestShopSign.getPrice(signLines),
+                () -> event.setOutcome(NO_PERMISSION));
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
@@ -3,7 +3,6 @@ package com.acrobot.chestshop.towny.listeners;
 import com.Acrobot.ChestShop.Events.PreShopCreationEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
 import com.acrobot.chestshop.towny.TownyUtils;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -23,8 +22,8 @@ public class PreShopCreationListener implements Listener {
 
         try {
             TownyUtils.checkShopPerms(player, ChestShopSign.getOwner(signLines), ChestShopSign.getPrice(signLines));
-        } catch (TownyException te) {
-            player.sendMessage(te.getMessage());
+        } catch (Exception e) {
+            player.sendMessage(e.getMessage());
             event.setOutcome(NO_PERMISSION);
         }
     }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/PreShopCreationListener.java
@@ -3,6 +3,7 @@ package com.acrobot.chestshop.towny.listeners;
 import com.Acrobot.ChestShop.Events.PreShopCreationEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
 import com.acrobot.chestshop.towny.TownyUtils;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,10 +21,11 @@ public class PreShopCreationListener implements Listener {
 
         String[] signLines = event.getSignLines();
 
-        TownyUtils.checkShopPerms(
-                player,
-                ChestShopSign.getOwner(signLines),
-                ChestShopSign.getPrice(signLines),
-                () -> event.setOutcome(NO_PERMISSION));
+        try {
+            TownyUtils.checkShopPerms(player, ChestShopSign.getOwner(signLines), ChestShopSign.getPrice(signLines));
+        } catch (TownyException te) {
+            player.sendMessage(te.getMessage());
+            event.setOutcome(NO_PERMISSION);
+        }
     }
 }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
@@ -1,0 +1,41 @@
+package com.acrobot.chestshop.towny.listeners;
+
+import com.Acrobot.ChestShop.Events.Protection.ProtectionCheckEvent;
+import com.Acrobot.ChestShop.Signs.ChestShopSign;
+import com.Acrobot.ChestShop.Utils.uBlock;
+import com.acrobot.chestshop.towny.TownyUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ProtectionCheckListener implements Listener {
+
+    @EventHandler
+    public void onProtectionCheck(ProtectionCheckEvent event) {
+        if (event.getResult() == Event.Result.DENY || event.isBuiltInProtectionIgnored()) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (com.Acrobot.ChestShop.Permission.has(player, com.Acrobot.ChestShop.Permission.ADMIN))
+            return;
+
+        Block block = event.getBlock();
+
+        if (uBlock.couldBeShopContainer(block)) {
+            Sign sign = uBlock.getConnectedSign(block);
+
+            if (sign == null)
+                return;
+
+            TownyUtils.checkShopPerms(
+                    player,
+                    ChestShopSign.getOwner(sign),
+                    ChestShopSign.getPrice(sign),
+                    () -> event.setResult(Event.Result.DENY));
+        }
+    }
+}

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
@@ -4,7 +4,6 @@ import com.Acrobot.ChestShop.Events.Protection.ProtectionCheckEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
 import com.Acrobot.ChestShop.Utils.uBlock;
 import com.acrobot.chestshop.towny.TownyUtils;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -34,8 +33,8 @@ public class ProtectionCheckListener implements Listener {
 
             try {
                 TownyUtils.checkShopPerms(player, ChestShopSign.getOwner(sign), ChestShopSign.getPrice(sign));
-            } catch (TownyException te) {
-                player.sendMessage(te.getMessage());
+            } catch (Exception e) {
+                player.sendMessage(e.getMessage());
                 event.setResult(Event.Result.DENY);
             }
         }

--- a/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
+++ b/src/main/java/com/acrobot/chestshop/towny/listeners/ProtectionCheckListener.java
@@ -4,6 +4,7 @@ import com.Acrobot.ChestShop.Events.Protection.ProtectionCheckEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
 import com.Acrobot.ChestShop.Utils.uBlock;
 import com.acrobot.chestshop.towny.TownyUtils;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -31,11 +32,12 @@ public class ProtectionCheckListener implements Listener {
             if (sign == null)
                 return;
 
-            TownyUtils.checkShopPerms(
-                    player,
-                    ChestShopSign.getOwner(sign),
-                    ChestShopSign.getPrice(sign),
-                    () -> event.setResult(Event.Result.DENY));
+            try {
+                TownyUtils.checkShopPerms(player, ChestShopSign.getOwner(sign), ChestShopSign.getPrice(sign));
+            } catch (TownyException te) {
+                player.sendMessage(te.getMessage());
+                event.setResult(Event.Result.DENY);
+            }
         }
     }
 }

--- a/src/main/java/com/acrobot/chestshop/towny/properties/Properties.java
+++ b/src/main/java/com/acrobot/chestshop/towny/properties/Properties.java
@@ -27,4 +27,7 @@ public class Properties {
 
     @ConfigurationComment("What should the nation name be prefixed with on the first line of the sign?")
     public static String NATION_SHOP_PREFIX = "n-";
+
+    @ConfigurationComment("Restrict chest access to players with permission for that specific shop type.")
+    public static boolean CHEST_ACCESS_BY_PERMISSION = true;
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,7 +12,13 @@ depend: [ChestShop, Towny]
 permissions:
   ChestShop.towny.bypass:
     default: op
-  ChestShop.towny.townshop:
+  ChestShop.towny.create.townshop:
     default: op
-  ChestShop.towny.nationshop:
+    children:
+      ChestShop.towny.create.townshop.buy: true
+      ChestShop.towny.create.townshop.sell: true
+  ChestShop.towny.create.nationshop:
     default: op
+    children:
+      ChestShop.towny.create.nationshop.buy: true
+      ChestShop.towny.create.nationshop.sell: true


### PR DESCRIPTION
This PR allows for the permissions to create buy and sell chest shops to be split, so that for example a player can just have the permission to create a town buy chestshop, but not to create town sell chestshop or visa versa. This also works with nation chestshops.

The permissions are:
- `ChestShop.towny.create.townshop` - Create buy or sell town chestshops.
- `ChestShop.towny.create.townshop.buy` - Only create buy town chestshops.
- `ChestShop.towny.create.townshop.sell` - Only create sell town chestshops.
- `ChestShop.towny.create.nationshop` - Create buy or sell nation chestshops
- `ChestShop.towny.create.nationshop.buy` - Only create buy nation chestshops.
- `ChestShop.towny.create.nationshop.sell` - Only create sell nation chestshops.